### PR TITLE
Correct tenant index removal on rollback

### DIFF
--- a/db/migrate/20241204043609_add_tenant_id_to_solidus_tables.rb
+++ b/db/migrate/20241204043609_add_tenant_id_to_solidus_tables.rb
@@ -96,7 +96,7 @@ class AddTenantIdToSolidusTables < ActiveRecord::Migration[7.0]
 
   def down
     TABLES.each do |table|
-      remove_index table
+      remove_index table, ::SolidusActsAsTenant.config.tenant_column_name
       remove_column table, ::SolidusActsAsTenant.config.tenant_column_name
     end
   end


### PR DESCRIPTION
ActiveRecord does not know which index to remove
if we do not use the column name in `remove_index`

```
$ bin/rails db:rollback
== 20250321193206 AddTenantIdToSolidusTables: reverting =======================
-- remove_index("spree_addresses")
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

No name or columns specified
/home/user/my_store/db/migrate/20250321193206_add_tenant_id_to_solidus_tables.solidus_acts_as_tenant.rb:101:in `block in down'
/home/user/my_store/db/migrate/20250321193206_add_tenant_id_to_solidus_tables.solidus_acts_as_tenant.rb:100:in `each'
/home/user/my_store/db/migrate/20250321193206_add_tenant_id_to_solidus_tables.solidus_acts_as_tenant.rb:100:in `down'

Caused by:
ArgumentError: No name or columns specified (ArgumentError)

          raise ArgumentError, "No name or columns specified" if checks.none?
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```